### PR TITLE
Allow composer to use Swiftmailer v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 
     "require": {
         "php": ">=5.4.0",
-        "swiftmailer/swiftmailer": "~5.3"
+        "swiftmailer/swiftmailer": ">=5.3"
     },
 
     "autoload": {


### PR DESCRIPTION
Swiftmailer v6 seems to work fine with phalcon-ext/mailer. Better to allow composer to update to Swiftmailer v6.
Swiftmailer v6 requires php7.