### PR TITLE
Fixed swiftmailer version to 5.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 
     "require": {
         "php": ">=5.4.0",
-        "swiftmailer/swiftmailer": ">=5.3"
+        "swiftmailer/swiftmailer": "^5.4"
     },
 
     "autoload": {


### PR DESCRIPTION
swiftmailer dropped mail() support on 6.x throwing an error requiring Swift_MailTransport class